### PR TITLE
Add makedirs() call to ensure logs directory exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ __pycache__/
 venv/
 .env
 *.egg-info
-
+logs/

--- a/src/mybot/logger.py
+++ b/src/mybot/logger.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import logging
 
 from .config.models import LoggerConfig
@@ -14,6 +15,7 @@ def setup_logger(logger_config: LoggerConfig):
         logger.addHandler(stream_handler)
 
     if logger_config.file_path:
+        os.makedirs(os.path.dirname(logger_config.file_path), exist_ok=True)
         file_handler = logging.FileHandler(logger_config.file_path)
         file_handler.setFormatter(logging.Formatter(logger_config.format))
         logger.addHandler(file_handler)


### PR DESCRIPTION
## Pull request to the async version
Not now

## Description
- Add makedirs() call to ensure logs directory exists,
- Add logs/ directory in .gitignore.

## Describe your tests
After `launch-polling` logs directory (-ies) will be created if not exists according to specified logger file path in configuration.

Python version: 3.10
OS: Linux, Ubuntu 22.04

## Checklist:
- [x] I added/edited example on new feature/change (if exists)
- [x] My changes won't break backward compatibility
- [ ] I made changes both for sync and async